### PR TITLE
Added DeepL.com Tracking

### DIFF
--- a/hosts
+++ b/hosts
@@ -420,3 +420,6 @@
 0.0.0.0 analytics-static.ugc.bazaarvoice.com
 0.0.0.0 bv-analytics-js-prod.s3.amazonaws.com
 0.0.0.0 bv-analytics-js-qa.s3.amazonaws.com
+
+# deepl.com
+0.0.0.0 s.deepl.com


### PR DESCRIPTION
Other than their website, the App DeepL for Windows sends a lot of tracking statistics to s.deepl.com using gRPC. This subdomain can be blocked without affecting the other functionality of the app.