### PR TITLE
Remove px-cloud.net from list of hosts

### DIFF
--- a/hosts
+++ b/hosts
@@ -34,7 +34,6 @@
 0.0.0.0 cdn.playwire.com
 0.0.0.0 cdn.snigelweb.com
 0.0.0.0 cdn.usefathom.com
-0.0.0.0 client.px-cloud.net
 0.0.0.0 dotmetrics.net
 0.0.0.0 ev.kck.st
 0.0.0.0 ezodn.com


### PR DESCRIPTION
PerimeterX (now HUMAN Security) is a major application security and anti fraud solution used by thousands of sites. px-cloud.net is used to interact with our service. Blocking this domain is causing issues across different web sites, from inability to transact to showing captcha.